### PR TITLE
InterfaceとType Aliasの違い

### DIFF
--- a/src/interface/interface.ts
+++ b/src/interface/interface.ts
@@ -65,3 +65,21 @@ const cotrip: Handbook = {
   title: 'ことりっぷ',
   theme: '旅行',
 }
+
+// —————————————————————————
+// implementsを使ってclassに型定義
+// —————————————————————————
+
+class Comic implements Book {
+  page: number
+  title: string
+  constructor(page: number, title: string, private publishYear: string) {
+    this.page = page
+    this.title = title
+  }
+  getPublishYear() {
+    return this.title + 'が発売されたのは' + this.publishYear + '年です。'
+  }
+}
+const popularComic = new Comic(200, '鬼滅の刃', 2016)
+console.log(popularComic.getPublishYear())

--- a/src/interface/interface.ts
+++ b/src/interface/interface.ts
@@ -1,0 +1,33 @@
+// —————————————————————————
+// Interfaceで表現
+// —————————————————————————
+
+interface Bread {
+  calories: number
+}
+interface Bread {
+  type: string
+}
+const francePan: Bread = {
+  calories: 300,
+  type: 'hard',
+}
+
+// —————————————————————————
+// 型エイリアスで表現
+// —————————————————————————
+
+type MaboDofu = {
+  calories: number
+  spicyLevel: number
+}
+type Rice = {
+  calories: number
+  gram: number
+}
+type MaboDon = MaboDofu & Rice // 交差型(union)
+const mabodon: MaboDon = {
+  calories: 500,
+  spicyLevel: 10,
+  gram: 350,
+}

--- a/src/interface/interface.ts
+++ b/src/interface/interface.ts
@@ -31,3 +31,37 @@ const mabodon: MaboDon = {
   spicyLevel: 10,
   gram: 350,
 }
+
+// —————————————————————————
+// インターフェースの継承
+// —————————————————————————
+
+interface Book {
+  page: number
+  title: string
+}
+interface Magazine extends Book {
+  cycle: 'daily' | 'weekly' | 'monthly' | 'yearly'
+}
+const jump: Magazine = {
+  page: 300,
+  title: '週刊少年ジャンプ',
+  cycle: 'weekly',
+}
+
+// —————————————————————————
+// インターフェースで型エイリアスを継承
+// —————————————————————————
+
+type BookType = {
+  page: number
+  title: string
+}
+interface Handbook extends BookType {
+  theme: string
+}
+const cotrip: Handbook = {
+  page: 120,
+  title: 'ことりっぷ',
+  theme: '旅行',
+}


### PR DESCRIPTION
### `Interface`と`Type Alias`の違い
- `Interface`と`Type Alias`のマージの違い
- `Interface`の継承
- `Interface`で`Type Alias`を継承
- `Interface`で`class`に型定義
    - `implements`を使用